### PR TITLE
Problema quando tem n remotes

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -9,7 +9,7 @@ require 'tty_integration.rb'
 module Config
   extend TtyIntegration
   def self.init
-    project_name = cmd.run!("git remote -v | head -n1 | awk '{print $2}' | sed -e 's,.*:\(.*/\)\?,,' -e 's/\.git$//'").out
+    project_name = cmd.run!("git remote -v | grep origin | head -n1 | awk '{print $2}' | sed -e 's,.*:\(.*/\)\?,,' -e 's/\.git$//'").out
     file = "#{Dir.home}/.config/gitsflow/#{project_name.gsub("\n","")}/config.yml"
     config = TTY::Config.new
     config.filename = file

--- a/lib/sflow/sflow.rb
+++ b/lib/sflow/sflow.rb
@@ -575,7 +575,7 @@ module SFlow
         @@bar.advance
       end
       Git.new_branch(branch)
-      Git.pull(parent_branch_name) unless parent_branch_name.empty?
+      Git.pull(parent_branch_name) unless parent_branch_name.nil?
       Git.push(branch)
 
       @@bar.finish


### PR DESCRIPTION
Problema:
- Quando se tem 2 _remotes_, ele pega o primeiro por ordem alfabética, no caso, se tenho um remote chamado origin e outro como modelo, ele pega o modelo e faz o processo para ele. No caso, é pra ser sempre o origin.

Solução:
- adicionei o _grep origin_ para pegar sempre do origin. (Solução paleativa para o nosso padrão atual)